### PR TITLE
The animate call needs moving out of the model build

### DIFF
--- a/app/components/3dmol/3dmol.directive.js
+++ b/app/components/3dmol/3dmol.directive.js
@@ -182,8 +182,8 @@ require.ensure(['script!3Dmol/build/3Dmol.js'], function(require) {
                         //$scope.viewer.zoomTo();
                         $scope.animModel.setStyle({}, $scope.style);
                         $scope.viewer.render();
-                        $scope.viewer.animate({interval: 75, loop: "forward", reps: 0});
                     }
+                    $scope.viewer.animate({interval: 75, loop: "forward", reps: 0});
                 }
             };
 


### PR DESCRIPTION
Sometimes we already have a model, and would like to resume the
animation that was paused.
