### PR TITLE
Use source maps in production to reduce bundle size

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = {
             style: path.join(__dirname, 'assets/style')
         }
     },
-    devtool: 'eval-source-map',
+    devtool: !production ? 'eval-source-map' : 'source-map',
     output: {
         path: path.join(__dirname, 'dist'),
         filename: 'bundle.js'


### PR DESCRIPTION
@cryos This should reduce our bundle size ...
