### PR TITLE
Fixed bug where cjson for the first calc was always used

### DIFF
--- a/app/components/3dmol/3dmol.directive.js
+++ b/app/components/3dmol/3dmol.directive.js
@@ -363,7 +363,7 @@ require.ensure(['script!3Dmol/build/3Dmol.js'], function(require) {
 
                 // TODO We shouldn't need to get the CJSON everytime
                 CJSON.get({
-                    id: $scope.calcs[0]._id
+                    id: $scope.selectedCalculation._id
                 },function(data) {
                     $scope.cjson = data.cjson;
                     $scope.modeFrames = $scope.generateFrames(mode);


### PR DESCRIPTION
We were incorrectly retrieving the cjson for the first calculation, even
though the chart was displaying the vibrational data for the selected
calculation. Thanks to Bert for spotting this.
