### PR TITLE
Fix OAuth login to work with Girder v1.4.0

### DIFF
--- a/app/components/login/login.dialog.jade
+++ b/app/components/login/login.dialog.jade
@@ -2,5 +2,5 @@ md-dialog
   md-dialog-content
     p Sign in with an OAuth provider
   div.md-actions
-    div(ng-repeat="(provider, url) in providers")
-      button.mongochem-oauth-button-google.md-button(ng-click="redirect(url)") Sign in with {{provider}}
+    div(ng-repeat="provider in providers track by provider.id")
+      button.mongochem-oauth-button-google.md-button(ng-click="redirect(provider.url)") Sign in with {{provider.name}}


### PR DESCRIPTION
The OAuth login API changed in Girder v1.4.0 (oauth plugin v2.1.0). This updates the client OAuth login dialog to use the changed API.
