### PR TITLE
Utilize sorting options when loading molecules

### DIFF
--- a/src/containers/calculations.js
+++ b/src/containers/calculations.js
@@ -12,8 +12,9 @@ import Calculations from '../components/calculations';
 class CalculationsContainer extends Component {
 
   componentDidMount() {
-    this.props.dispatch(molecules.loadMolecules());
-    this.props.dispatch(calculations.loadCalculations());
+    const options = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
+    this.props.dispatch(molecules.loadMolecules(options));
+    this.props.dispatch(calculations.loadCalculations(options));
   }
 
   onOpen = (id) => {

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -12,7 +12,7 @@ import Molecules from '../components/molecules';
 class MoleculesContainer extends Component {
 
   componentDidMount() {
-    var options = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
+    const options = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
     this.props.dispatch(molecules.loadMolecules(options));
   }
 

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -12,7 +12,8 @@ import Molecules from '../components/molecules';
 class MoleculesContainer extends Component {
 
   componentDidMount() {
-    this.props.dispatch(molecules.loadMolecules());
+    var options = { limit: 25, offset: 0, sort: '_id', sortDir: -1 }
+    this.props.dispatch(molecules.loadMolecules(options));
   }
 
   onOpen = (inchikey) => {

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -12,7 +12,7 @@ import Molecules from '../components/molecules';
 class MoleculesContainer extends Component {
 
   componentDidMount() {
-    var options = { limit: 25, offset: 0, sort: '_id', sortDir: -1 }
+    var options = { limit: 25, offset: 0, sort: '_id', sortdir: -1 }
     this.props.dispatch(molecules.loadMolecules(options));
   }
 


### PR DESCRIPTION
Utilize sorting options when loading molecules from girder.
The limit and offset seem to work at least. But the sorting
doesn't appear to work yet...

This PR depends on [this one](https://github.com/OpenChemistry/oc-web-components/pull/111).

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>