### PR TITLE
Show SVG if molecule does not have 3D coordinates

### DIFF
--- a/src/components/calculation/index.js
+++ b/src/components/calculation/index.js
@@ -14,6 +14,7 @@ import PageHead from '../page-head';
 import PageBody from '../page-body';
 import CardComponent from '../item-details-card';
 import { formatFormula } from '../../utils/formulas';
+import { has3dCoords } from '../../utils/molecules';
 import { camelToSpace, toUpperCase } from '../../utils/strings';
 import { getCalculationProperties } from '../../utils/calculations';
 import DownloadSelector from '../download-selector';
@@ -187,6 +188,50 @@ class Calculation extends Component {
       })
     }
 
+    function getMoleculeView() {
+      // For some reason, the molecule is sometimes null
+      // Do a check here to prevent a javascript error
+      if (molecule === null)
+        return;
+
+      if (has3dCoords(molecule)) {
+        return (
+          <oc-molecule
+            ref={wc(
+              // Events
+              {
+                iOrbitalChanged: onIOrbitalChanged
+              },
+              //Props
+              {
+                cjson: {...cjson, cube},
+                orbitalSelect: true,
+                moleculeRenderer,
+                showIsoSurface,
+                showVolume,
+                showSpectrum,
+                showMenu,
+                isoValue,
+                iOrbital,
+                iMode: mode,
+                play,
+                colors,
+                colorsX,
+                opacities,
+                opacitiesX
+              }
+            )}
+          />
+        )
+      }
+      else {
+        const src = `${window.location.origin}/api/v1/molecules/${molecule._id}/svg`
+        return (
+          <img src={src} class={classes.moleculeContainer}/>
+        )
+      }
+    }
+
     return(
       <div>
         <PageHead>
@@ -198,32 +243,7 @@ class Calculation extends Component {
           <Grid container spacing={24}>
             <Grid item xs={12} sm={12} md={8}>
               <Card className={classes.moleculeContainer}>
-                <oc-molecule
-                  ref={wc(
-                    // Events
-                    {
-                      iOrbitalChanged: onIOrbitalChanged
-                    },
-                    //Props
-                    {
-                      cjson: {...cjson, cube},
-                      orbitalSelect: true,
-                      moleculeRenderer,
-                      showIsoSurface,
-                      showVolume,
-                      showSpectrum,
-                      showMenu,
-                      isoValue,
-                      iOrbital,
-                      iMode: mode,
-                      play,
-                      colors,
-                      colorsX,
-                      opacities,
-                      opacitiesX
-                    }
-                  )}
-                />
+                {getMoleculeView()}
               </Card>
               { showNotebooks &&
               <div className={classes.buttonDiv}>
@@ -234,7 +254,7 @@ class Calculation extends Component {
               }
             </Grid>
             <Grid item xs={12} sm={12} md={4}>
-              {sections.map((section, i) => 
+              {sections.map((section, i) =>
                 <CardComponent
                   key={i}
                   title={section.label}

--- a/src/components/molecule.js
+++ b/src/components/molecule.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import PropTypes from 'prop-types';
 
-import { withStyles, Grid, Card, CardMedia, Typography } from '@material-ui/core';
+import { withStyles, Grid, Card, Typography } from '@material-ui/core';
 
 import { has } from 'lodash-es';
 
@@ -55,12 +55,9 @@ class Molecule extends Component {
       )
     }
     else {
-      const image = `${window.location.origin}/api/v1/molecules/${molecule._id}/svg`
+      const src = `${window.location.origin}/api/v1/molecules/${molecule._id}/svg`
       return (
-        <CardMedia
-          className={classes.moleculeContainer}
-          image={image}
-        />
+        <img src={src} class={classes.moleculeContainer}/>
       )
     }
   }

--- a/src/components/molecule.js
+++ b/src/components/molecule.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import PropTypes from 'prop-types';
 
-import { withStyles, Grid, Card, Typography } from '@material-ui/core';
+import { withStyles, Grid, Card, CardMedia, Typography } from '@material-ui/core';
 
 import { has } from 'lodash-es';
 
@@ -11,6 +11,7 @@ import PageBody from './page-body';
 import CardComponent from './item-details-card';
 
 import { formatFormula } from '../utils/formulas';
+import { has3dCoords } from '../utils/molecules';
 
 import { wc } from '../utils/webcomponent';
 import { getCalculationProperties } from '../utils/calculations';
@@ -34,6 +35,34 @@ class Molecule extends Component {
     else if (molecule.properties.formula)
       return formatFormula(molecule.properties.formula);
     return 'Molecule';
+  }
+
+  getMoleculeView(molecule, classes) {
+    if (has3dCoords(molecule)) {
+      return (
+        <oc-molecule
+          ref={wc(
+            // Events
+            {},
+            //Props
+            {
+              cjson: molecule.cjson,
+              rotate: this.state.rotate,
+              moleculeRenderer: 'moljs'
+            }
+          )}
+        />
+      )
+    }
+    else {
+      const image = `${window.location.origin}/api/v1/molecules/${molecule._id}/svg`
+      return (
+        <CardMedia
+          className={classes.moleculeContainer}
+          image={image}
+        />
+      )
+    }
   }
 
   constructor(props) {
@@ -107,22 +136,11 @@ class Molecule extends Component {
         <Grid container spacing={24}>
             <Grid item xs={12} sm={12} md={8}>
               <Card className={classes.moleculeContainer}>
-                <oc-molecule
-                  ref={wc(
-                    // Events
-                    {},
-                    //Props
-                    {
-                      cjson: molecule.cjson,
-                      rotate: this.state.rotate,
-                      moleculeRenderer: 'moljs'
-                    }
-                  )}
-                />
+                {this.getMoleculeView(molecule, classes)}
               </Card>
             </Grid>
             <Grid item xs={12} sm={12} md={4}>
-              {sections.map((section, i) => 
+              {sections.map((section, i) =>
                 <CardComponent
                   key={i}
                   title={section.label}

--- a/src/utils/molecules.js
+++ b/src/utils/molecules.js
@@ -1,0 +1,9 @@
+import { get } from 'lodash-es';
+
+export function has3dCoords(molecule) {
+  const coords = get(molecule, 'cjson.atoms.coords.3d')
+  if (coords === undefined || coords.length == 0)
+    return false
+
+  return true
+}

--- a/src/utils/molecules.js
+++ b/src/utils/molecules.js
@@ -2,8 +2,5 @@ import { get } from 'lodash-es';
 
 export function has3dCoords(molecule) {
   const coords = get(molecule, 'cjson.atoms.coords.3d')
-  if (coords === undefined || coords.length == 0)
-    return false
-
-  return true
+  return coords !== undefined && coords.length > 0
 }


### PR DESCRIPTION
This seems to work with a few caveats:

1. The svg does not seem to resize if you do something like open the javascript console window. It probably should.
2. If you load a molecule with 3D coordinates, the SVG flashes on the screen temporarily before the 3D renderer appears.

I still need to add it to the calculation pages as well.

Example:
![Screenshot from 2019-06-06 14-04-15](https://user-images.githubusercontent.com/9558430/59055587-33486380-8864-11e9-886c-b639969a1b6c.png)

Example of not resizing if you open the javascript console window:
![Screenshot from 2019-06-06 14-04-55](https://user-images.githubusercontent.com/9558430/59055603-3cd1cb80-8864-11e9-9612-0291be01df44.png)