### PR TITLE
Allow for advanced searches for molecules

### DIFF
--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -7,6 +7,9 @@ import SearchIcon from '@material-ui/icons/Search';
 import { defaultTo } from 'lodash-es';
 
 const SearchTooltip = withStyles(theme => ({
+  popper: {
+    opacity: 1.0,
+  },
   tooltip: {
     backgroundColor: '#f5f5f9',
     color: 'rgba(0, 0, 0, 1.0)',

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
 
 import { InputBase, withStyles, Select, MenuItem, InputAdornment, IconButton, Paper } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
+
+import { defaultTo } from 'lodash-es';
 
 const styles = theme => ({
   root: {
@@ -32,7 +35,7 @@ const styles = theme => ({
   }
 });
 
-const SearchForm = ({fields, onSubmit, classes}) => {
+const SearchForm = ({fields, onSubmit, tooltips, classes}) => {
   const [currentField, setCurrentField] = useState(0);
   const [fieldValue, setFieldValue] = useState(fields[0].initialValue);
 
@@ -66,9 +69,13 @@ const SearchForm = ({fields, onSubmit, classes}) => {
     <MenuItem key={i} value={i}>{label}</MenuItem>
   ));
 
+  const curFieldName = fields[currentField].name;
+  const tooltip = defaultTo(tooltips[curFieldName], '');
+
   return (
     <Paper className={classes.root}>
     <form onSubmit={handleSubmit}>
+      <Tooltip title={tooltip}>
         <div className={classes.fieldContainer}>
           <Select
             value={currentField} onChange={e => {onCurrentFieldChange(e.target.value)}}
@@ -89,6 +96,7 @@ const SearchForm = ({fields, onSubmit, classes}) => {
             }
           />
         </div>
+      </Tooltip>
     </form>
     </Paper>
   );

--- a/src/components/search/index.js
+++ b/src/components/search/index.js
@@ -6,6 +6,16 @@ import SearchIcon from '@material-ui/icons/Search';
 
 import { defaultTo } from 'lodash-es';
 
+const SearchTooltip = withStyles(theme => ({
+  tooltip: {
+    backgroundColor: '#f5f5f9',
+    color: 'rgba(0, 0, 0, 1.0)',
+    maxWidth: 800,
+    fontSize: theme.typography.pxToRem(16),
+    border: '1px solid #dadde9',
+  },
+}))(Tooltip);
+
 const styles = theme => ({
   root: {
   },
@@ -75,7 +85,7 @@ const SearchForm = ({fields, onSubmit, tooltips, classes}) => {
   return (
     <Paper className={classes.root}>
     <form onSubmit={handleSubmit}>
-      <Tooltip title={tooltip}>
+      <SearchTooltip title={tooltip}>
         <div className={classes.fieldContainer}>
           <Select
             value={currentField} onChange={e => {onCurrentFieldChange(e.target.value)}}
@@ -96,7 +106,7 @@ const SearchForm = ({fields, onSubmit, tooltips, classes}) => {
             }
           />
         </div>
-      </Tooltip>
+      </SearchTooltip>
     </form>
     </Paper>
   );

--- a/src/containers/calculations.js
+++ b/src/containers/calculations.js
@@ -121,6 +121,7 @@ class CalculationsContainer extends Component {
           <SearchForm
             fields={searchFields}
             onSubmit={this.onSearchChange}
+            tooltips={{}}
           />
         }
         after={

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -5,11 +5,12 @@ import { push } from 'connected-react-router';
 import { selectors } from '@openchemistry/redux'
 import { molecules } from '@openchemistry/redux'
 
-import { isNil } from 'lodash-es';
+import { isNil, has } from 'lodash-es';
 
 import PaginationSort from '../components/pagination-sort';
 import Molecules from '../components/molecules';
 import SearchForm from '../components/search';
+import { advancedSearchToMolQuery } from '../utils/search';
 
 const sortOptions = [
   {
@@ -47,7 +48,8 @@ const searchFields = [
   {name: 'name', type: 'text', label: 'Name', initialValue: ''},
   {name: 'inchi', type: 'text', label: 'Inchi', initialValue: ''},
   {name: 'inchikey', type: 'text', label: 'Inchi Key', initialValue: ''},
-  {name: 'smiles', type: 'text', label: 'Smiles', initialValue: ''}
+  {name: 'smiles', type: 'text', label: 'Smiles', initialValue: ''},
+  {name: 'advanced', type: 'text', label: 'Advanced', initialValue: ''}
 ]
 
 class MoleculesContainer extends Component {
@@ -114,6 +116,11 @@ class MoleculesContainer extends Component {
   }
 
   onOptionsChange = (pagination, search) => {
+    if (has(search, 'advanced') && search.advanced !== undefined) {
+      // advanced gets special treatment
+      search.queryString = advancedSearchToMolQuery(search.advanced);
+      delete search.advanced
+    }
     const options = {...pagination, ...search};
     this.props.dispatch(molecules.loadMolecules(options));
   }

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -78,14 +78,13 @@ const advancedLogicalOperators = [
 ]
 
 const advancedTooltip = (
-  // Needed for newlines in tooltips
-  <div style={{whiteSpace: 'pre-line'}}>
-  {
-    'Fields: ' + advancedFields.join(', ') + '\n' +
-    'Comparison Operators: ' + advancedComparisonOperators.join(', ') + '\n' +
-    'Logical Operators: ' + advancedLogicalOperators.join(', ')
-  }
-  </div>
+  <React.Fragment>
+    <b>{'Fields: '}</b> {advancedFields.join(', ')} <br/>
+    <b>{'Comparison Operators: '}</b>
+    {advancedComparisonOperators.join(', ')} <br/>
+    <b>{'Logical Operators: '}</b> {advancedLogicalOperators.join(', ')} <br/>
+    <b>{'Example: '}</b> {'mass >= 200 and atomCount < 40'}
+  </React.Fragment>
 );
 
 const tooltips = {

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -5,7 +5,7 @@ import { push } from 'connected-react-router';
 import { selectors } from '@openchemistry/redux'
 import { molecules } from '@openchemistry/redux'
 
-import { isNil, has } from 'lodash-es';
+import { has, isNil } from 'lodash-es';
 
 import PaginationSort from '../components/pagination-sort';
 import Molecules from '../components/molecules';
@@ -51,6 +51,51 @@ const searchFields = [
   {name: 'smiles', type: 'text', label: 'Smiles', initialValue: ''},
   {name: 'advanced', type: 'text', label: 'Advanced', initialValue: ''}
 ]
+
+const advancedFields = [
+  'mass',
+  'atomCount',
+  'heavyAtomCount',
+  'inchi',
+  'inchikey',
+  'name',
+  'formula',
+  'smiles'
+]
+
+const advancedComparisonOperators = [
+  '==',
+  '!=',
+  '>=',
+  '<=',
+  '>',
+  '<'
+]
+
+const advancedLogicalOperators = [
+  'and',
+  'or'
+]
+
+const advancedTooltip = (
+  // Needed for newlines in tooltips
+  <div style={{whiteSpace: 'pre-line'}}>
+  {
+    'Fields: ' + advancedFields.join(', ') + '\n' +
+    'Comparison Operators: ' + advancedComparisonOperators.join(', ') + '\n' +
+    'Logical Operators: ' + advancedLogicalOperators.join(', ')
+  }
+  </div>
+);
+
+const tooltips = {
+  'formula': '',
+  'name': '',
+  'inchi': '',
+  'inchikey': '',
+  'smiles': '',
+  'advanced': advancedTooltip
+}
 
 class MoleculesContainer extends Component {
 
@@ -138,6 +183,7 @@ class MoleculesContainer extends Component {
           <SearchForm
             fields={searchFields}
             onSubmit={this.onSearchChange}
+            tooltips={tooltips}
           />
         }
         after={

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -1,0 +1,27 @@
+// It is important to put two character operators first
+const operatorDict = {
+  '!=': '~ne~',
+  '>=': '~gte~',
+  '<=': '~lte~',
+  '>': '~gt~',
+  '<': '~lt~',
+  '==': '~eq~',
+  ' and ': '~and~',
+  ' or ': '~or~'
+}
+
+export function advancedSearchToMolQuery(search) {
+  if (search === undefined)
+    return search;
+
+  let s = search;
+  for (const key in operatorDict) {
+    // Replace all case-insensitive
+    const regExp = new RegExp(key, 'gi');
+    s = s.replace(regExp, operatorDict[key]);
+  }
+
+  // Remove all spaces
+  s = s.replace(/\s+/g, '');
+  return s;
+}


### PR DESCRIPTION
In an advanced search, you can do things like the following:

`mass >= 200 and atomCount <= 50`

The way I currently have it set up, spaces are not required except
for around the logical operators 'and' and 'or' (to distinguish them
from any substrings in a string). '==' is the equality operator,
because you can also do things like:

`smiles == C1=CC=CC=C1`

And we need to be able to distinguish between '==' and '=' in smiles.

Let me know if I should change any of these things.

The fields that are searchable are: inchi, inchikey, name, formula,
smiles, mass, atomCount, and heavyAtomCount.

This depends on [this PR](https://github.com/OpenChemistry/mongochemserver/pull/140).

Fixes: #132

Examples are shown below.
![im1](https://user-images.githubusercontent.com/9558430/60208185-ac185b00-9825-11e9-9447-215cffdf68b5.png)
![im2](https://user-images.githubusercontent.com/9558430/60208196-afabe200-9825-11e9-982d-4109f4561c7a.png)
