### PR TITLE
Remember previous location in pagination

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -50,7 +50,7 @@ class SideBar extends Component {
 
         <MenuItem
           style={style.menu}
-          onClick={() => pushRoute('/molecules') }
+          onClick={() => pushRoute('/molecules?limit=16&offset=0&sort=_id&sortdir=-1&sortIndex=0') }
         >
           <GroupIcon color="primary" />&nbsp;
           <Typography color="inherit" variant="subheading">Molecules</Typography>


### PR DESCRIPTION
If navigating away from molecule results, navigating back will take you to the location you were previously at in the results - if you are on page 3 of the molecule results, viewing a molecule and then going back will return you to page 3 rather than the begining of the results.

Signed-off-by: Brianna Major <brianna.major@kitware.com>