### PR TITLE
Pagination history

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -71,7 +71,7 @@ class SideBar extends Component {
         <MenuItem
           dense
           style={style.menu}
-          onClick={() => pushRoute('/molecules?limit=16&offset=0&sort=_id&sortdir=-1&sortIndex=0') }
+          onClick={() => pushRoute('/molecules') }
         >
           <GroupIcon color="primary" />&nbsp;
           <Typography color="inherit" variant="subheading">Molecules</Typography>
@@ -80,7 +80,7 @@ class SideBar extends Component {
         {userId
           ? <MenuItem
             style={style.submenu}
-            onClick={() => pushRoute('/user/' + userId + '/molecules?limit=16&offset=0&sort=_id&sortdir=-1&sortIndex=0') }
+            onClick={() => pushRoute('/user/' + userId + '/molecules') }
           >
             <GroupIcon style={style.subicon} color="primary" />&nbsp;
             <Typography color="inherit" variant="subtitle2">My Molecules</Typography>

--- a/src/containers/calculations.js
+++ b/src/containers/calculations.js
@@ -5,7 +5,7 @@ import { push } from 'connected-react-router';
 import { selectors } from '@openchemistry/redux'
 import { calculations, molecules } from '@openchemistry/redux'
 
-import { isNil } from 'lodash-es';
+import { isNil, isUndefined } from 'lodash-es';
 
 import PaginationSort from '../components/pagination-sort';
 import Calculations from '../components/calculations';
@@ -163,7 +163,7 @@ class CalculationsContainer extends Component {
     const {sortIndex} = this.state;
     const {sortdir, sort, limit, offset} = pagination;
     for (let val in search) {
-      if (search[val] === undefined) {
+      if (isUndefined(search[val])) {
         search[val] = '';
       }
     }

--- a/src/containers/calculations.js
+++ b/src/containers/calculations.js
@@ -44,22 +44,68 @@ class CalculationsContainer extends Component {
 
   constructor(props) {
     super(props);
+    const params = new URLSearchParams(props.location.search);
     this.state = {
-      sortIndex: 0,
-      paginationOptions: { limit: 16, offset: 0, sort: '_id', sortdir: -1 },
-      searchOptions: {}
+      sortIndex: params.get('sortIndex') || 0,
+      paginationOptions: {
+        limit: params.get('limit') || 16,
+        offset: params.get('offset') || 0,
+        sort: params.get('sort') ? params.get('sort').toString() : '_id',
+        sortdir: params.get('sortdir') || -1
+      },
+      searchOptions: {
+        formula: params.get('formula') || '',
+        name: params.get('name') || '',
+        inchi: params.get('inchi') || '',
+        inchikey: params.get('inchikey') || '',
+        smiles: params.get('smiles') || ''
+      }
     }
   }
 
   componentDidMount() {
-    const { paginationOptions } = this.state;
+    const { paginationOptions, searchOptions } = this.state;
     var creatorId = null;
     if (this.props.match.params.id) {
       creatorId = this.props.match.params.id;
     }
-    this.props.dispatch(calculations.loadCalculations({options: paginationOptions, loadMolecules: true, creatorId: creatorId}));
+    const options = {...paginationOptions, ...searchOptions}
+    this.props.dispatch(calculations.loadCalculations({options, loadMolecules: true, creatorId: creatorId}));
   }
 
+  componentDidUpdate(prevProps) {
+    const currSearch = this.props.location.search;
+    const prevSearch = prevProps.location.search;
+    const params = new URLSearchParams(currSearch);
+    const reload = (
+      this.props.history.action === 'POP' || params.get('offset') == 0);
+    if (currSearch !== prevSearch && reload) {
+      var offset = params.get('offset')
+      this.setState({
+        sortIndex: params.get('sortIndex') || 0,
+        paginationOptions: {
+          limit: params.get('limit') || 16,
+          offset: params.get('offset') || 0,
+          sort: params.get('sort') ? params.get('sort').toString() : '_id',
+          sortdir: params.get('sortdir') || -1
+        },
+        searchOptions: {
+          formula: params.get('formula') || '',
+          name: params.get('name') || '',
+          inchi: params.get('inchi') || '',
+          inchikey: params.get('inchikey') || '',
+          smiles: params.get('smiles') || ''
+        }
+      }, () => {
+        const options = {...this.state.paginationOptions, ...this.state.searchOptions};
+        var creatorId = null;
+        if (this.props.match.params.id) {
+          creatorId = this.props.match.params.id;
+        }
+        this.props.dispatch(calculations.loadCalculations({options, loadMolecules: true, creatorId}));
+      });
+    }
+  }
   onOpen = (id) => {
     this.props.dispatch(push(`/calculations/${id}?mo=homo`));
   }
@@ -113,7 +159,19 @@ class CalculationsContainer extends Component {
     if (this.props.match.params.id) {
       creatorId = this.props.match.params.id;
     }
+
+    const {sortIndex} = this.state;
+    const {sortdir, sort, limit, offset} = pagination;
+    for (let val in search) {
+      if (search[val] === undefined) {
+        search[val] = '';
+      }
+    }
+    const params = {sortIndex, sortdir, sort, limit, offset, ...search};
+    const query = new URLSearchParams(params).toString();
+
     this.props.dispatch(calculations.loadCalculations({options, loadMolecules: true, creatorId}));
+    this.props.dispatch(push({pathname:'/calculations', search:query}));
   }
 
   render() {

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -102,12 +102,12 @@ class MoleculesContainer extends Component {
     super(props);
     const params = new URLSearchParams(props.location.search);
     this.state = {
-      sortIndex: params.get('sortIndex'),
+      sortIndex: params.get('sortIndex') || 0,
       paginationOptions: {
-        limit: params.get('limit'),
-        offset: params.get('offset'),
-        sort: params.get('sort').toString(),
-        sortdir: params.get('sortdir')
+        limit: params.get('limit') || 16,
+        offset: params.get('offset') || 0,
+        sort: params.get('sort') ? params.get('sort').toString() : '_id',
+        sortdir: params.get('sortdir') || -1
       },
       searchOptions: {
         formula: params.get('formula') || '',
@@ -140,12 +140,12 @@ class MoleculesContainer extends Component {
     if (currSearch !== prevSearch && reload) {
       var offset = params.get('offset')
       this.setState({
-        sortIndex: params.get('sortIndex'),
+        sortIndex: params.get('sortIndex') || 0,
         paginationOptions: {
-          limit: params.get('limit'),
-          offset: offset,
-          sort: params.get('sort').toString(),
-          sortdir: params.get('sortdir')
+          limit: params.get('limit') || 16,
+          offset: params.get('offset') || 0,
+          sort: params.get('sort') ? params.get('sort').toString() : '_id',
+          sortdir: params.get('sortdir') || -1
         },
         searchOptions: {
           formula: params.get('formula') || '',

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -109,16 +109,25 @@ class MoleculesContainer extends Component {
         sort: params.get('sort').toString(),
         sortdir: params.get('sortdir')
       },
-      searchOptions: params.get('searchOptions')
+      searchOptions: {
+        formula: params.get('formula') || '',
+        name: params.get('name') || '',
+        inchi: params.get('inchi') || '',
+        inchikey: params.get('inchikey') || '',
+        smiles: params.get('smiles') || ''
+      }
     }
   }
 
   componentDidMount() {
-    const options = this.state.paginationOptions;
+    const { paginationOptions, searchOptions } = this.state;
     var creatorId = null;
     if (this.props.match.params.id) {
       creatorId = this.props.match.params.id;
     }
+    const options = {...paginationOptions, ...searchOptions}
+    Object.keys(options).forEach(
+      (key) => (options[key] == '') && delete options[key]);
     this.props.dispatch(molecules.loadMolecules({options, creatorId}));
   }
 
@@ -138,9 +147,17 @@ class MoleculesContainer extends Component {
           sort: params.get('sort').toString(),
           sortdir: params.get('sortdir')
         },
-        searchOptions: params.get('searchOptions')
+        searchOptions: {
+          formula: params.get('formula') || '',
+          name: params.get('name') || '',
+          inchi: params.get('inchi') || '',
+          inchikey: params.get('inchikey') || '',
+          smiles: params.get('smiles') || ''
+        }
       }, () => {
-        const options = this.state.paginationOptions;
+        const options = {...this.state.paginationOptions, ...this.state.searchOptions};
+        Object.keys(options).forEach(
+          (key) => (options[key] == '') && delete options[key]);
         var creatorId = null;
         if (this.props.match.params.id) {
           creatorId = this.props.match.params.id;
@@ -208,12 +225,19 @@ class MoleculesContainer extends Component {
     if (this.props.match.params.id) {
       creatorId = this.props.match.params.id;
     }
-    
+
     const {sortIndex} = this.state;
     const {sortdir, sort, limit, offset} = pagination;
-    const params = {sortIndex, sortdir, sort, limit, offset};
+    for (let val in search) {
+      if (search[val] === undefined) {
+        search[val] = '';
+      }
+    }
+    const params = {sortIndex, sortdir, sort, limit, offset, ...search};
     const query = new URLSearchParams(params).toString();
 
+    Object.keys(options).forEach(
+      (key) => (options[key] == '') && delete options[key]);
     this.props.dispatch(molecules.loadMolecules({options, creatorId}));
     this.props.dispatch(push({pathname:'/molecules', search:query}));
   }

--- a/src/containers/molecules.js
+++ b/src/containers/molecules.js
@@ -5,7 +5,7 @@ import { push } from 'connected-react-router';
 import { selectors } from '@openchemistry/redux'
 import { molecules } from '@openchemistry/redux'
 
-import { has, isNil, isEqual } from 'lodash-es';
+import { has, isNil, isUndefined } from 'lodash-es';
 
 import PaginationSort from '../components/pagination-sort';
 import Molecules from '../components/molecules';
@@ -229,7 +229,7 @@ class MoleculesContainer extends Component {
     const {sortIndex} = this.state;
     const {sortdir, sort, limit, offset} = pagination;
     for (let val in search) {
-      if (search[val] === undefined) {
+      if (isUndefined(search[val])) {
         search[val] = '';
       }
     }


### PR DESCRIPTION
This branch adds in pagination history for calculation routes, as well as takes into account search parameters for both molecule and calculation routes. 

Previously, searching for a molecule or calculation, selecting one to view, then returning to the previous page loaded the first page of molecules or calculations, rather than the actual previous page of search results. Remembering search parameters fixes that.