### PR TITLE
If a calculation has a version number, display it

### DIFF
--- a/src/components/calculations.js
+++ b/src/components/calculations.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { has } from 'lodash-es';
+import { has, filter, eq } from 'lodash-es';
 import { withStyles } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
@@ -52,7 +52,10 @@ class Calculations extends Component {
                 const title = this.getName(calculation);
                 const image = `${window.location.origin}/api/v1/molecules/${calculation.moleculeId}/svg`;
                 const pending = has(calculation, 'properties.pending');
-                const properties = getCalculationProperties(calculation);
+                let properties = getCalculationProperties(calculation);
+                properties = filter(properties, function(obj) {
+                  return !eq(obj.label, 'Version');
+                  });
 
                 return (
                   <Grid key={calculation._id} item xs={12} sm={6} md={4} lg={3}>

--- a/src/utils/calculations.js
+++ b/src/utils/calculations.js
@@ -38,6 +38,9 @@ export const getCalculationProperties = (calculation) => {
   if (has(calculation, 'image.repository')) {
     properties.push({label: 'Code', value: formatCode(calculation.image.repository)});
   }
+  if (has(calculation, 'code.version')) {
+    properties.push({label: 'Version', value: calculation.code.version});
+  }
   if (has(calculation, 'input.parameters.task')) {
     properties.push({label: 'Type', value: formatTask(calculation.input.parameters.task)});
   }


### PR DESCRIPTION
In the Calculations card on a molecule page and in the Input card on a
calculation page, display the calculation's version number if it has one. Do not
display the version number when browsing all calculations.

Signed-off-by: Brianna Major <brianna.major@kitware.com>