### PR TITLE
Fix the calculation notebook view

### DIFF
--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -19,7 +19,7 @@ const styles = () => ({
   container: {
     overflow: 'hidden',
     position: 'relative',
-    paddingTop: '72%'
+    paddingTop: '100%'
   }
 });
 

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -3,22 +3,13 @@ import PropTypes from 'prop-types';
 import Iframe from 'react-iframe'
 
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/core/styles';
 
 import PageHead from './page-head';
 import PageBody from './page-body';
 
-const appStyles = theme => ({
-  iframe: {
-    width: '100%',
-    height: '-webkit-fill-available'
-  }
-})
-
-class Notebook extends Component {
-
+export default class Notebook extends Component {
    render = () => {
-    const {classes, fileId} = this.props;
+    const {fileId} = this.props;
     const baseUrl =  `${window.location.origin}/api/v1`;
     return (
       <div>
@@ -28,7 +19,14 @@ class Notebook extends Component {
           </Typography>
         </PageHead>
         <PageBody>
-          <Iframe className={classes.iframe} url={`${baseUrl}/notebooks/${fileId}/html`}/>
+          <Iframe id='iframe' url={`${baseUrl}/notebooks/${fileId}/html`}
+          width='100%'
+          onLoad={function(){
+            var frame = document.getElementById('iframe');
+            if (frame) {
+              frame.height = frame.contentWindow.document.body.scrollHeight + 'px';
+            }
+          }}/>
         </PageBody>
       </div>
     );
@@ -43,5 +41,3 @@ Notebook.defaultProps = {
 
   fileId: null,
 }
-
-export default withStyles(appStyles)(Notebook)

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -2,14 +2,30 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Iframe from 'react-iframe'
 
-import Typography from '@material-ui/core/Typography';
+import { Typography, withStyles } from '@material-ui/core';
 
 import PageHead from './page-head';
 import PageBody from './page-body';
 
-export default class Notebook extends Component {
+const styles = () => ({
+  iframe: {
+    border: 0,
+    left: 0,
+    position: 'absolute',
+    top: 0,
+    width:'100%',
+    height:'100%'
+  },
+  container: {
+    overflow: 'hidden',
+    position: 'relative',
+    paddingTop: '72%'
+  }
+});
+
+class Notebook extends Component {
    render = () => {
-    const {fileId} = this.props;
+    const { fileId, classes } = this.props;
     const baseUrl =  `${window.location.origin}/api/v1`;
     return (
       <div>
@@ -19,14 +35,10 @@ export default class Notebook extends Component {
           </Typography>
         </PageHead>
         <PageBody>
+        <div className={classes.container}>
           <Iframe id='iframe' url={`${baseUrl}/notebooks/${fileId}/html`}
-          width='100%'
-          onLoad={function(){
-            var frame = document.getElementById('iframe');
-            if (frame) {
-              frame.height = frame.contentWindow.document.body.scrollHeight + 'px';
-            }
-          }}/>
+          className={classes.iframe}/>
+        </div>
         </PageBody>
       </div>
     );
@@ -41,3 +53,5 @@ Notebook.defaultProps = {
 
   fileId: null,
 }
+
+export default withStyles(styles)(Notebook)

--- a/src/components/notebook.js
+++ b/src/components/notebook.js
@@ -3,14 +3,22 @@ import PropTypes from 'prop-types';
 import Iframe from 'react-iframe'
 
 import Typography from '@material-ui/core/Typography';
+import { withStyles } from '@material-ui/core/styles';
 
 import PageHead from './page-head';
 import PageBody from './page-body';
 
-export default class Notebook extends Component {
+const appStyles = theme => ({
+  iframe: {
+    width: '100%',
+    height: '-webkit-fill-available'
+  }
+})
+
+class Notebook extends Component {
 
    render = () => {
-    const {fileId} = this.props;
+    const {classes, fileId} = this.props;
     const baseUrl =  `${window.location.origin}/api/v1`;
     return (
       <div>
@@ -20,10 +28,7 @@ export default class Notebook extends Component {
           </Typography>
         </PageHead>
         <PageBody>
-          <Iframe url={`${baseUrl}/notebooks/${fileId}/html`}
-            width="100%"
-            height="60rem"
-          />
+          <Iframe className={classes.iframe} url={`${baseUrl}/notebooks/${fileId}/html`}/>
         </PageBody>
       </div>
     );
@@ -39,3 +44,4 @@ Notebook.defaultProps = {
   fileId: null,
 }
 
+export default withStyles(appStyles)(Notebook)


### PR DESCRIPTION
The view was previously limited to a height of 60px. The notebook height is now
determined by the available space.

Signed-off-by: Brianna Major <brianna.major@kitware.com>