### PR TITLE
Use react-app-rewired to allow custom aliases

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,13 @@
+const path = require('path');
+module.exports = {
+  webpack: (config, env) => {
+    if (env === 'development') {
+      config.resolve.alias = {
+        react: path.resolve('node_modules/react'),
+        'react-redux': path.resolve('node_modules/react-redux'),
+        '@openchemistry': path.resolve('node_modules/@openchemistry')
+      };
+    }
+    return config;
+  },
+};

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,18 +1,16 @@
 const path = require('path');
 module.exports = {
   webpack: (config, env) => {
-    if (env === 'development') {
-      config.resolve.alias = {
-        'react': path.resolve('node_modules/react'),
-        'react-dom': path.resolve('node_modules/react-dom'),
-        'react-redux': path.resolve('node_modules/react-redux'),
-        'redux': path.resolve('node_modules/redux'),
-        'redux-saga': path.resolve('node_modules/redux-saga'),
-        'redux-form': path.resolve('node_modules/redux-form'),
-        '@material-ui': path.resolve('node_modules/@material-ui'),
-        '@openchemistry': path.resolve('node_modules/@openchemistry')
-      };
-    }
+    config.resolve.alias = {
+      'react': path.resolve('node_modules/react'),
+      'react-dom': path.resolve('node_modules/react-dom'),
+      'react-redux': path.resolve('node_modules/react-redux'),
+      'redux': path.resolve('node_modules/redux'),
+      'redux-saga': path.resolve('node_modules/redux-saga'),
+      'redux-form': path.resolve('node_modules/redux-form'),
+      '@material-ui': path.resolve('node_modules/@material-ui'),
+      '@openchemistry': path.resolve('node_modules/@openchemistry')
+    };
     return config;
   },
 };

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -3,8 +3,13 @@ module.exports = {
   webpack: (config, env) => {
     if (env === 'development') {
       config.resolve.alias = {
-        react: path.resolve('node_modules/react'),
+        'react': path.resolve('node_modules/react'),
+        'react-dom': path.resolve('node_modules/react-dom'),
         'react-redux': path.resolve('node_modules/react-redux'),
+        'redux': path.resolve('node_modules/redux'),
+        'redux-saga': path.resolve('node_modules/redux-saga'),
+        'redux-form': path.resolve('node_modules/redux-form'),
+        '@material-ui': path.resolve('node_modules/@material-ui'),
         '@openchemistry': path.resolve('node_modules/@openchemistry')
       };
     }

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "redux-saga": "^1.0.2",
     "universal-cookie": "^3.0.7"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "react-app-rewired": "^2.1.8"
+  },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject"
   },
   "browserslist": [


### PR DESCRIPTION
Add react-app-rewired to allow us to inject custom aliases to resolve issues with multiple versions of react being included in the bundle. There currently doesn't seem like there is a better way todo this.